### PR TITLE
Allow custom path separators

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -63,7 +63,7 @@ func (F *Frisby) ExpectJson(path string, value interface{}) *Frisby {
 	}
 
 	if path != "" {
-		path_items := strings.Split(path, ".")
+		path_items := strings.Split(path, Global.PathSeparator)
 		simp_json = simp_json.GetPath(path_items...)
 	}
 	json := simp_json.Interface()
@@ -112,7 +112,7 @@ func (F *Frisby) ExpectJsonType(path string, val_type reflect.Kind) *Frisby {
 	}
 
 	if path != "" {
-		path_items := strings.Split(path, ".")
+		path_items := strings.Split(path, Global.PathSeparator)
 		json = json.GetPath(path_items...)
 	}
 
@@ -141,7 +141,7 @@ func (F *Frisby) ExpectJsonLength(path string, length int) *Frisby {
 	}
 
 	if path != "" {
-		path_items := strings.Split(path, ".")
+		path_items := strings.Split(path, Global.PathSeparator)
 		json = json.GetPath(path_items...)
 	}
 

--- a/global.go
+++ b/global.go
@@ -19,12 +19,17 @@ type global_data struct {
 
 	PrintProgressName bool
 	PrintProgressDot  bool
+
+	PathSeparator string
 }
+
+const DefaultPathSeparator = "."
 
 func init() {
 	Global.Req = request.NewRequest(new(http.Client))
 	Global.Errs = make(map[string][]error, 0)
 	Global.PrintProgressDot = true
+	Global.PathSeparator = DefaultPathSeparator
 }
 
 // Set BasicAuth values for the coming request


### PR DESCRIPTION
This adds `PathSeparator` to the `global_data` struct. I don't think we need to use a setter method, that's not really idiomatic go so I've just added it as an exported field.