### PR TITLE
Print the actual value not its type

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -107,7 +107,7 @@ func (F *Frisby) ExpectJson(path string, value interface{}) *Frisby {
 	}
 
 	if !equal {
-		err_str := fmt.Sprintf("ExpectJson equality test failed for %q, got type: %v", path, reflect.TypeOf(json))
+		err_str := fmt.Sprintf("ExpectJson equality test failed for %q, got: %v", path, json)
 		F.AddError(err_str)
 	}
 


### PR DESCRIPTION
It's kinda pesky getting "test failed for 'x', got type: string" when what you really want to know is what the string was, since that's the mismatch. This updates the expectation to print the actual value, rather than the type, or the actual value.