### PR TITLE
added Key parameter for AddFiles function

### DIFF
--- a/frisby.go
+++ b/frisby.go
@@ -11,6 +11,8 @@ import (
 
 var Global global_data
 
+const defaultFileKey = "file"
+
 type Frisby struct {
 	Name   string
 	Url    string
@@ -191,12 +193,15 @@ func (F *Frisby) SetJson(json interface{}) *Frisby {
 }
 
 // Add a file to the Form data for the coming request
-func (F *Frisby) AddFile(filename string) *Frisby {
+func (F *Frisby) AddFile(key, filename string) *Frisby {
 	file, err := os.Open(filename)
 	if err != nil {
 		F.Errs = append(F.Errs, err)
 	} else {
-		fileField := request.FileField{"file", filename, file}
+		if len(key) == 0 {
+			key = defaultFileKey
+		}
+		fileField := request.FileField{key, filename, file}
 		F.Req.Files = append(F.Req.Files, fileField)
 	}
 	return F


### PR DESCRIPTION
Using all the time the same key "file" for uploading files is not that flexible. If you provide a key parameter you can easily change the key. I provided the "file" key as default value if you leave the key with an empty string.

If you have any questions or suggestions, please let me know.
