### PR TITLE
Feature/imrpove filename from full dir to base name

### DIFF
--- a/frisby.go
+++ b/frisby.go
@@ -11,6 +11,8 @@ import (
 
 var Global global_data
 
+const defaultFileKey = "file"
+
 type Frisby struct {
 	Name   string
 	Url    string
@@ -191,12 +193,15 @@ func (F *Frisby) SetJson(json interface{}) *Frisby {
 }
 
 // Add a file to the Form data for the coming request
-func (F *Frisby) AddFile(filename string) *Frisby {
+func (F *Frisby) AddFile(key, filename string) *Frisby {
 	file, err := os.Open(filename)
 	if err != nil {
 		F.Errs = append(F.Errs, err)
 	} else {
-		fileField := request.FileField{"file", filename, file}
+		if len(key) == 0 {
+			key = defaultFileKey
+		}
+		fileField := request.FileField{key, filename, file}
 		F.Req.Files = append(F.Req.Files, fileField)
 	}
 	return F

--- a/frisby.go
+++ b/frisby.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/mozillazg/request"
 )
@@ -201,7 +202,10 @@ func (F *Frisby) AddFile(key, filename string) *Frisby {
 		if len(key) == 0 {
 			key = defaultFileKey
 		}
-		fileField := request.FileField{key, filename, file}
+		fileField := request.FileField{
+			FieldName: key,
+			FileName:  filepath.Base(filename),
+			File:      file}
 		F.Req.Files = append(F.Req.Files, fileField)
 	}
 	return F


### PR DESCRIPTION
This provides that the server sees just the base name of the file and not the whole file path to the file. The server can handle by them self the file in which directory it will be saved.
