### PR TITLE
Fix for nil error when calling SetParam on frisyb.Create(...)

### DIFF
--- a/frisby.go
+++ b/frisby.go
@@ -40,6 +40,9 @@ func Create(name string) *Frisby {
 	F.Req.Json = Global.Req.Json
 	F.Req.Files = append(F.Req.Files, Global.Req.Files...)
 
+	// initialize request
+	F.Req.Params = make(map[string]string)
+
 	return F
 }
 


### PR DESCRIPTION
How to recreate:
frisby.Create("Test GET /resource?type=xyz").
        SetHeader("Content-Type", "application/json").
        Get(GetAbsURL("/resource")).
        SetParam(“type”, “xyz”).
        Send()

Error:
    panic: assignment to entry in nil map [recovered]
    panic: assignment to entry in nil map