### PR TITLE
New functions PrintGoTestReport() and PauseTest() added

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ Functions called after `Send()`
 * AfterContent( func(Frisby,[]byte,error) )
 * AfterText( func(Frisby,string,error) )
 * AfterJson( func(Frisby,simplejson.Json,error) )
+* PauseTest(t time.Duration)
 * PrintBody()
 * PrintReport()
+* PrintGoTestReport()
 
 
 ### More examples
@@ -238,4 +240,3 @@ For 7 requests made
 ```
 
 ![catch!](https://raw.github.com/verdverm/frisby/master/frisby.gif)
-

--- a/expect.go
+++ b/expect.go
@@ -248,3 +248,18 @@ func (F *Frisby) PrintReport() *Frisby {
 
 	return F
 }
+
+// Prints a report for the Frisby Object in go_test format
+//
+// If there are any errors, they will all be printed as well
+func (F *Frisby) PrintGoTestReport() *Frisby {
+	if len(F.Errs) == 0 {
+		fmt.Printf("=== RUN   %s\n--- PASS: %s (%.2fs)\n", F.Name, F.Name, F.ExecutionTime)
+	} else {
+		fmt.Printf("=== RUN   %s\n--- FAIL: %s (%.2fs)\n", F.Name, F.Name, F.ExecutionTime)
+		for _, e := range F.Errs {
+			fmt.Println("	", e)
+		}
+	}
+	return F
+}

--- a/frisby.go
+++ b/frisby.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/mozillazg/request"
 )
@@ -16,9 +17,10 @@ type Frisby struct {
 	Url    string
 	Method string
 
-	Req  *request.Request
-	Resp *request.Response
-	Errs []error
+	Req           *request.Request
+	Resp          *request.Response
+	Errs          []error
+	ExecutionTime float64
 }
 
 // Creates a new Frisby object with the given name.
@@ -208,8 +210,10 @@ func (F *Frisby) Send() *Frisby {
 	if Global.PrintProgressName {
 		fmt.Println(F.Name)
 	} else if Global.PrintProgressDot {
-		fmt.Printf(".")
+		fmt.Printf("")
 	}
+
+	start := time.Now()
 
 	var err error
 	switch F.Method {
@@ -228,6 +232,8 @@ func (F *Frisby) Send() *Frisby {
 	case "OPTIONS":
 		F.Resp, err = F.Req.Options(F.Url)
 	}
+
+	F.ExecutionTime = time.Since(start).Seconds()
 
 	if err != nil {
 		F.Errs = append(F.Errs, err)
@@ -259,4 +265,10 @@ func (F *Frisby) Error() error {
 // This function should be called last
 func (F *Frisby) Errors() []error {
 	return F.Errs
+}
+
+// Pause your testrun for a defined amount of seconds
+func (F *Frisby) PauseTest(t time.Duration) *Frisby {
+	time.Sleep(t * time.Second)
+	return nil
 }


### PR DESCRIPTION
By using PrintGoTestReport() you get exatly the format, that is also used by go-test. This makes it easier to display the frisby response in jenkins for example.

This example works well, if you were using the PrintGoTestReport func:
_go run main.go | go-junit-report -set-exit-code > test_report.xml_